### PR TITLE
Prefill template metadata

### DIFF
--- a/backend/routes/prompts/blocks/__init__.py
+++ b/backend/routes/prompts/blocks/__init__.py
@@ -7,8 +7,11 @@ from . import update_block
 from . import delete_block
 from . import get_block_types
 from . import seed_sample_blocks
+from . import get_block
 
 __all__ = [
     "router",
     "supabase",
+    "get_block",
 ]
+

--- a/backend/routes/prompts/blocks/get_block.py
+++ b/backend/routes/prompts/blocks/get_block.py
@@ -1,0 +1,30 @@
+from fastapi import Depends, HTTPException
+from .helpers import router, supabase, get_access_conditions
+from models.prompts.blocks import BlockResponse
+from models.common import APIResponse
+from utils import supabase_helpers
+
+@router.get("/{block_id}", response_model=APIResponse[BlockResponse])
+async def get_block(
+    block_id: int,
+    user_id: str = Depends(supabase_helpers.get_user_from_session_token),
+):
+    """Retrieve a single block by ID if user has access."""
+    try:
+        access_conditions = get_access_conditions(supabase, user_id)
+        response = (
+            supabase.table("prompt_blocks")
+            .select("*")
+            .eq("id", block_id)
+            .or_(",".join(access_conditions))
+            .single()
+            .execute()
+        )
+        if not response.data:
+            raise HTTPException(status_code=404, detail="Block not found")
+        return APIResponse(success=True, data=response.data)
+    except Exception as e:
+        if isinstance(e, HTTPException):
+            raise e
+        raise HTTPException(status_code=500, detail=f"Error retrieving block: {str(e)}")
+

--- a/frontend/src/hooks/dialogs/useCreateTemplateDialog.ts
+++ b/frontend/src/hooks/dialogs/useCreateTemplateDialog.ts
@@ -32,6 +32,7 @@ import {
   updateMetadataItem,
   reorderMetadataItems
 } from './templateDialogUtils';
+import { prefillMetadataFromMapping } from '@/utils/templates/metadataPrefill';
 
 export function useCreateTemplateDialog() {
   const createDialog = useDialog('createTemplate');
@@ -89,6 +90,12 @@ export function useCreateTemplateDialog() {
               title: { en: 'Template Content' }
             }
           ]);
+        }
+
+        if (currentTemplate.enhanced_metadata) {
+          setMetadata(currentTemplate.enhanced_metadata);
+        } else if (currentTemplate.metadata) {
+          prefillMetadataFromMapping(currentTemplate.metadata).then(setMetadata);
         }
       } else {
         setName('');

--- a/frontend/src/hooks/dialogs/useCustomizeTemplateDialog.ts
+++ b/frontend/src/hooks/dialogs/useCustomizeTemplateDialog.ts
@@ -27,6 +27,7 @@ import {
   updateMetadataItem,
   reorderMetadataItems
 } from './templateDialogUtils';
+import { prefillMetadataFromMapping } from '@/utils/templates/metadataPrefill';
 
 export function useCustomizeTemplateDialog() {
   const { isOpen, data, dialogProps } = useDialog('placeholderEditor');
@@ -72,6 +73,10 @@ export function useCustomizeTemplateDialog() {
 
         setBlocks(templateBlocks);
         setMetadata(templateMetadata);
+
+        if (!data.enhanced_metadata && data.metadata) {
+          prefillMetadataFromMapping(data.metadata).then(setMetadata);
+        }
       } catch (err) {
         console.error('PlaceholderEditor: Error processing template:', err);
         setError(getMessage('errorProcessingTemplate'));

--- a/frontend/src/services/api/BlocksApi.ts
+++ b/frontend/src/services/api/BlocksApi.ts
@@ -119,6 +119,22 @@ export class BlocksApi {
   }
 
   /**
+   * Fetch a single block by ID
+   */
+  async getBlock(blockId: number): Promise<any> {
+    try {
+      return await apiClient.request(`/prompts/blocks/${blockId}`);
+    } catch (error) {
+      console.error('Error fetching block:', error);
+      return {
+        success: false,
+        data: null,
+        message: error instanceof Error ? error.message : 'Unknown error'
+      };
+    }
+  }
+
+  /**
    * Get all available block types
    */
   async getBlockTypes(): Promise<any> {

--- a/frontend/src/utils/templates/metadataPrefill.ts
+++ b/frontend/src/utils/templates/metadataPrefill.ts
@@ -1,0 +1,40 @@
+import { blocksApi } from '@/services/api/BlocksApi';
+import {
+  PromptMetadata,
+  DEFAULT_METADATA,
+  SingleMetadataType,
+  MultipleMetadataType,
+  MetadataItem,
+  generateMetadataItemId,
+  isMultipleMetadataType
+} from '@/types/prompts/metadata';
+import { getLocalizedContent } from '@/components/prompts/blocks/blockUtils';
+
+export async function prefillMetadataFromMapping(
+  mapping: Record<string, number | number[]>
+): Promise<PromptMetadata> {
+  const result: PromptMetadata = { ...DEFAULT_METADATA, values: {} as Record<SingleMetadataType, string> };
+
+  if (!mapping) return result;
+
+  const entries = Object.entries(mapping);
+  for (const [key, val] of entries) {
+    if (Array.isArray(val)) {
+      const items: MetadataItem[] = [];
+      for (const id of val) {
+        const res = await blocksApi.getBlock(id as number);
+        const value = res.success && res.data ? getLocalizedContent(res.data.content) : '';
+        items.push({ id: generateMetadataItemId(), blockId: id as number, value });
+      }
+      (result as any)[key] = items;
+    } else {
+      const id = val as number;
+      const res = await blocksApi.getBlock(id);
+      const value = res.success && res.data ? getLocalizedContent(res.data.content) : '';
+      (result as any)[key] = id;
+      result.values![key as SingleMetadataType] = value;
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- add API route to fetch individual prompt blocks
- add `BlocksApi.getBlock` client call
- implement `prefillMetadataFromMapping` helper
- preload metadata values when opening templates in dialogs and actions

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6846a713a09c8325813cd54024db922d